### PR TITLE
fix(FEC-13176): The icons in the more plugin are incorrect

### DIFF
--- a/src/services/upper-bar-manager/ui/dropdown-bar/dropdown-bar.component.tsx
+++ b/src/services/upper-bar-manager/ui/dropdown-bar/dropdown-bar.component.tsx
@@ -14,7 +14,7 @@ export class DropdownBar extends Component<DropdownBarProps> {
   render(): ComponentChild {
     return (
       <div className={styles.moreDropdown} role="menu" aria-expanded="true">
-        {this.props.controls.map(({ id, label, svgIcon, onClick }, index) => {
+        {this.props.controls.map(({ id, label, svgIcon, onClick }) => {
           return (
             <Fragment key={id}>
               <A11yWrapper
@@ -26,7 +26,7 @@ export class DropdownBar extends Component<DropdownBarProps> {
               >
                 <div className={styles.dropdownItem} tabIndex={0} aria-label={label}>
                   <div className={styles.icon}>
-                    <Icon id={`icon${index}`} path={svgIcon.path} viewBox={svgIcon.viewBox} />
+                    <Icon id={`icon${id}`} path={svgIcon.path} viewBox={svgIcon.viewBox} />
                   </div>
                   <span className={styles.dropdownItemDescription}>{label}</span>
                 </div>


### PR DESCRIPTION
### Description of the Changes

Solves: https://kaltura.atlassian.net/browse/FEC-13176

Preact optimizes re-rendering arrays of data by using uniq keys for each array item. If data dynamic (in case of "more plugin" for small player size "more plugin" renders 2 icons in upper bar - other icons in dropdown. For large size - "more plugin" rensers 4 icons in upper bar - other icons in dropdown). As key for icon uses element index in array - so if player size changed from small to large - amount of icons in dropdown changed but indexes - no, first icon still has index (key) - 0, second one - 1.
It causes issue with re-render of icons, Preact doesn't re-render icons because indexes haven't changed.

Solution - use icon id (uniq id for icons in "more plugin") that force Preact correctly render icons if player size changed.
