### PR TITLE
fix(FEC-13214): Top Bar Dropdown menu are not auto closed on Transcript or Navigation icon clicked

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,6 @@
     "name": "uiManagers"
   },
   "dependencies": {
-    "@playkit-js/common": "^1.2.3"
+    "@playkit-js/common": "^1.2.10"
   }
 }

--- a/src/services/upper-bar-manager/ui/displayed-bar/displayed-bar.component.tsx
+++ b/src/services/upper-bar-manager/ui/displayed-bar/displayed-bar.component.tsx
@@ -1,4 +1,4 @@
-import { h, Component, ComponentChild, RefObject, createRef } from 'preact';
+import { h, Component, ComponentChild, RefObject } from 'preact';
 import { IconModel } from '../../models/icon-model';
 import { IconWrapper } from '../icon-wrapper/icon-wrapper.component';
 import * as styles from './displayed-bar.component.scss';

--- a/src/services/upper-bar-manager/ui/displayed-bar/displayed-bar.component.tsx
+++ b/src/services/upper-bar-manager/ui/displayed-bar/displayed-bar.component.tsx
@@ -90,8 +90,8 @@ export class DisplayedBar extends Component<DisplayedBarProps & PropsFromRedux, 
           return (
             <IconWrapper
               key={id}
-              onClick={(e): void => {
-                onClick(e);
+              onClick={(...e): void => {
+                onClick(...e);
                 this.closeDropdown();
               }}
               ref={componentRef}

--- a/src/services/upper-bar-manager/ui/displayed-bar/displayed-bar.component.tsx
+++ b/src/services/upper-bar-manager/ui/displayed-bar/displayed-bar.component.tsx
@@ -16,7 +16,7 @@ const mapStateToProps = (state) => ({
 });
 
 type DisplayedBarState = {
-  toggle: boolean;
+  showDropdown: boolean;
 };
 
 type DisplayedBarProps = {
@@ -33,15 +33,15 @@ type PropsFromRedux = {
 export class DisplayedBar extends Component<DisplayedBarProps & PropsFromRedux, DisplayedBarState> {
   constructor() {
     super();
-    this.state = { toggle: false };
+    this.state = { showDropdown: false };
   }
 
   private handleOnClick = (): void => {
-    this.setState((prevState) => ({ toggle: !prevState.toggle }));
+    this.setState((prevState) => ({ showDropdown: !prevState.showDropdown }));
   };
 
   private closeDropdown(): void {
-    this.setState({ toggle: false });
+    this.setState({ showDropdown: false });
   }
 
   private splitControlsIntoDisplayedAndDropdown(): {
@@ -101,7 +101,7 @@ export class DisplayedBar extends Component<DisplayedBarProps & PropsFromRedux, 
           );
         })}
         {dropdownControls.length > 0 && (
-          <MoreIcon showDropdown={this.state.toggle} onClick={this.handleOnClick} icons={dropdownControls} />
+          <MoreIcon showDropdown={this.state.showDropdown} onClick={this.handleOnClick} icons={dropdownControls} />
         )}
       </div>
     );

--- a/src/services/upper-bar-manager/ui/dropdown-bar/dropdown-bar.component.tsx
+++ b/src/services/upper-bar-manager/ui/dropdown-bar/dropdown-bar.component.tsx
@@ -18,7 +18,7 @@ export class DropdownBar extends Component<DropdownBarProps> {
           return (
             <Fragment key={id}>
               <A11yWrapper
-                onClick={(e) => {
+                onClick={(e): void => {
                   onClick(e);
                   this.props.onDropdownClick();
                 }}

--- a/src/services/upper-bar-manager/ui/icon-wrapper/icon-wrapper.component.tsx
+++ b/src/services/upper-bar-manager/ui/icon-wrapper/icon-wrapper.component.tsx
@@ -1,26 +1,17 @@
 import { h, Component, ComponentChild, RefObject, cloneElement, VNode } from 'preact';
-import { ui } from '@playkit-js/kaltura-player-js';
-const { KeyMap } = ui.utils;
+import { A11yWrapper } from '@playkit-js/common/dist/hoc/a11y-wrapper';
 
 type IconWrapperProps = {
   ref: RefObject<IconWrapper>;
   onClick: (e: MouseEvent | KeyboardEvent) => void;
 };
 
-// eslint-disable-next-line react/prefer-stateless-function
 export class IconWrapper extends Component<IconWrapperProps> {
-  private handleOnKeyDown(event: KeyboardEvent): void {
-    if (event.keyCode === KeyMap.ENTER || event.keyCode === KeyMap.SPACE) {
-      event.preventDefault();
-      this.props.onClick(event);
-    }
-  }
-
   render(): ComponentChild {
     return (
-      <div onClick={this.props.onClick} onKeyDown={(event): void => this.handleOnKeyDown(event)}>
-        {cloneElement(this.props.children as VNode)}
-      </div>
+      <A11yWrapper onClick={this.props.onClick}>
+        <div>{cloneElement(this.props.children as VNode)}</div>
+      </A11yWrapper>
     );
   }
 }

--- a/src/services/upper-bar-manager/ui/more-icon/more-icon.component.tsx
+++ b/src/services/upper-bar-manager/ui/more-icon/more-icon.component.tsx
@@ -14,22 +14,20 @@ const ICON_PATH =
   // eslint-disable-next-line max-len
   'M16 22a3 3 0 1 1 0 6 3 3 0 0 1 0-6zm0 2a1 1 0 1 0 0 2 1 1 0 0 0 0-2zm0-11a3 3 0 1 1 0 6 3 3 0 0 1 0-6zm0 2a1 1 0 1 0 0 2 1 1 0 0 0 0-2zm0-11a3 3 0 1 1 0 6 3 3 0 0 1 0-6zm0 2a1 1 0 1 0 0 2 1 1 0 0 0 0-2z';
 
-type MoreIconState = {
-  toggle: boolean;
-};
 type MoreIconProps = {
   icons: IconModel[];
+  onClick: () => void;
+  showDropdown: boolean;
   moreIconTxt?: string;
   eventManager?: EventManager;
 };
 
 @withEventManager
 @withText({ moreIconTxt: <Text id="controls.moreIcon">More</Text> })
-export class MoreIcon extends Component<MoreIconProps, MoreIconState> {
+export class MoreIcon extends Component<MoreIconProps> {
   private readonly moreButtonRef: RefObject<HTMLButtonElement>;
   constructor() {
     super();
-    this.state = { toggle: false };
     this.moreButtonRef = createRef();
   }
 
@@ -38,27 +36,16 @@ export class MoreIcon extends Component<MoreIconProps, MoreIconState> {
   }
 
   handleClickOutside(event: PointerEvent): void {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    if (this.moreButtonRef && !this.moreButtonRef.current!.contains(event.target)) {
+    if (this.moreButtonRef && !this.moreButtonRef.current!.contains(event.target as Node)) {
       this.setState({ toggle: false });
     }
   }
 
-  private handleOnClick = (): void => {
-    this.setState((prevState) => ({ toggle: !prevState.toggle }));
-  };
-
-  private onDropdownClick = (): void => {
-    this.setState({ toggle: false });
-  };
-
-  // close icon when click outside
   render(): ComponentChild {
     return (
       <div style={{ position: 'relative' }}>
         <Tooltip label={this.props.moreIconTxt!}>
-          <A11yWrapper onClick={this.handleOnClick}>
+          <A11yWrapper onClick={this.props.onClick}>
             <button
               ref={this.moreButtonRef}
               className={`${ui.style.upperBarIcon} ${styles.moreIcon}`}
@@ -69,9 +56,9 @@ export class MoreIcon extends Component<MoreIconProps, MoreIconState> {
             </button>
           </A11yWrapper>
         </Tooltip>
-        {this.state.toggle && (
+        {this.props.showDropdown && (
           <div>
-            <DropdownBar onDropdownClick={this.onDropdownClick} controls={this.props.icons} />
+            <DropdownBar onDropdownClick={this.props.onClick} controls={this.props.icons} />
           </div>
         )}
       </div>

--- a/src/services/upper-bar-manager/upper-bar-manager.tsx
+++ b/src/services/upper-bar-manager/upper-bar-manager.tsx
@@ -61,10 +61,10 @@ export class UpperBarManager {
     }
   }
 
-  private _getControls = (iconsOrder: IconsOrder) => {
+  private getControls(iconsOrder: IconsOrder): IconModel[] {
     const icons = Array.from(this.componentsRegistry.values());
     return icons.sort((a, b) => (iconsOrder[a.label] > iconsOrder[b.label] ? 1 : -1));
-  };
+  }
 
   private injectDisplayedBarComponentWrapper(iconsOrder: IconsOrder): void {
     this.player.ui.addComponent({
@@ -72,7 +72,7 @@ export class UpperBarManager {
       presets: [ReservedPresetNames.Playback, ReservedPresetNames.Live],
       area: ReservedPresetAreas.TopBarRightControls,
       get: () => {
-        return <DisplayedBar ref={this.displayedBarComponentRef} getControls={() => this._getControls(iconsOrder)} />;
+        return <DisplayedBar ref={this.displayedBarComponentRef} getControls={(): IconModel[] => this.getControls(iconsOrder)} />;
       }
     });
   }

--- a/tests/e2e/upper-bar-manager.spec.js
+++ b/tests/e2e/upper-bar-manager.spec.js
@@ -133,7 +133,7 @@ describe('Upper Bar Manager', () => {
 
     player.ready().then(() => {
       setTimeout(() => {
-        const displayedBarComponentState = upperBarManagerService._getControls(pluginsConfig.uiManagers.upperBarManager.pluginsIconsOrder);
+        const displayedBarComponentState = upperBarManagerService.getControls(pluginsConfig.uiManagers.upperBarManager.pluginsIconsOrder);
         expect(displayedBarComponentState[0].label).to.be.equal('pluginC');
         expect(displayedBarComponentState[1].label).to.be.equal('pluginF');
         expect(displayedBarComponentState[2].label).to.be.equal('pluginA');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1146,10 +1146,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@playkit-js/common@^1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@playkit-js/common/-/common-1.2.3.tgz#29bf06e966ad97d5d077e0e28b1803b9cb6714fb"
-  integrity sha512-c3SHyQQ9Y9iM1q/6Gaay1GA9INkHQqg7uMJPP8AeXBjfyTs1H4W96EDAAX/96iDCYLjxZbp4UBsMR3RmTN9OrA==
+"@playkit-js/common@^1.2.10":
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/@playkit-js/common/-/common-1.2.10.tgz#c66edc706ae449689b53ccf342dc0eb9f18a9dbe"
+  integrity sha512-jmh08OLxizkddFH7m8w6UGkC5Z9GvIIsl3Ol5Vp2o5d00MvIRho8bUJISPR+ac0mQY/WarpbFm8iRQl7Kwo+oQ==
   dependencies:
     "@playkit-js/playkit-js-ui" "^0.77.1"
     classnames "^2.3.2"


### PR DESCRIPTION
### Description of the Changes

**issue:** upper bar icons on click handlers were not consistently executed in the UI managers but some were handled by plugins and some by the UI Managers.
in addition, the state toggle of the dropdown bar was under the more-icon component control and therefore the dropdown was not closed when the display-bar icon were clicked

**fix:** remove the on-click handler from the button component from all plugins and pass it just once to the upper bar manager, and lifting the toggle state of the dropdown up

solves FEC-13214

related prs:
https://github.com/kaltura/playkit-js-transcript/pull/148
https://github.com/kaltura/playkit-js-moderation/pull/59
https://github.com/kaltura/playkit-js-info/pull/55
https://github.com/kaltura/playkit-js-navigation/pull/326
https://github.com/kaltura/playkit-js-qna/pull/324
https://github.com/kaltura/playkit-js-common/pull/24

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
