### PR TITLE
fix(SUP-38494):In screen reader with keyboard navigation, button labe…

### DIFF
--- a/src/services/upper-bar-manager/ui/icon-wrapper/icon-wrapper.component.tsx
+++ b/src/services/upper-bar-manager/ui/icon-wrapper/icon-wrapper.component.tsx
@@ -9,7 +9,7 @@ type IconWrapperProps = {
 export class IconWrapper extends Component<IconWrapperProps> {
   render(): ComponentChild {
     return (
-      <A11yWrapper onClick={this.props.onClick}>
+      <A11yWrapper role="generic" onClick={this.props.onClick}>
         <div>{cloneElement(this.props.children as VNode)}</div>
       </A11yWrapper>
     );


### PR DESCRIPTION
the issue:
jaws screen reader read plugin button 2 times when it has role='button' on <div> and then <button> as child

solution:
change role="generic" on wrapper for plugins