### PR TITLE
feat: manage presets in upper-bar

### DIFF
--- a/src/services/upper-bar-manager/models/icon-dto.ts
+++ b/src/services/upper-bar-manager/models/icon-dto.ts
@@ -1,6 +1,7 @@
 import { ComponentClass, FunctionalComponent } from 'preact';
 import { SvgIcon } from './svg-icon';
 import { KalturaPluginNames } from '../../../types/ui-managers-config';
+import { PlaykitUI } from '@playkit-js/kaltura-player-js';
 
 export interface IconDto {
   /**
@@ -25,4 +26,8 @@ export interface IconDto {
    * (also useful as backwards compatibility for some plugins)
    */
   onClick: (e: MouseEvent | KeyboardEvent) => void;
+  /**
+   * Relevant presets for the icon
+   */
+  presets?: PlaykitUI.ReservedPresetName[];
 }

--- a/src/services/upper-bar-manager/models/icon-model.ts
+++ b/src/services/upper-bar-manager/models/icon-model.ts
@@ -3,6 +3,8 @@ import { IconDto } from './icon-dto';
 import { IconWrapper } from '../ui/icon-wrapper/icon-wrapper.component';
 import { SvgIcon } from './svg-icon';
 import { KalturaPluginNames } from '../../../types/ui-managers-config';
+import { PlaykitUI, ui } from '@playkit-js/kaltura-player-js';
+const { ReservedPresetNames } = ui;
 
 export class IconModel {
   private static nextId = 0;
@@ -12,6 +14,7 @@ export class IconModel {
   public onClick: (e: MouseEvent | KeyboardEvent) => void;
   public component: ComponentClass<Record<string, never>> | FunctionalComponent<Record<string, never>>;
   public svgIcon: SvgIcon;
+  public presets: PlaykitUI.ReservedPresetName[];
   constructor(item: IconDto) {
     this.id = ++IconModel.nextId;
     this.label = item.label;
@@ -19,6 +22,8 @@ export class IconModel {
     this.svgIcon = item.svgIcon;
     this.onClick = item.onClick;
     this.componentRef = createRef();
+    this.presets =
+      item.presets && item.presets.length > 0 ? item.presets : [ReservedPresetNames.Playback, ReservedPresetNames.Live];
   }
 
   public update(): void {

--- a/src/services/upper-bar-manager/upper-bar-manager.tsx
+++ b/src/services/upper-bar-manager/upper-bar-manager.tsx
@@ -6,6 +6,10 @@ import { DisplayedBar } from './ui/displayed-bar/displayed-bar.component';
 import { KalturaPluginNames } from '../../types/ui-managers-config';
 const { ReservedPresetAreas, ReservedPresetNames } = ui;
 
+const relevantPresets = Object.values(ReservedPresetNames).filter(
+  (preset) => preset !== ReservedPresetNames.Idle && preset !== ReservedPresetNames.Error
+);
+
 type UpperBarManagerConfig = { pluginsIconsOrder: { [key in KalturaPluginNames | string]: number } };
 type IconsOrder = { [key in KalturaPluginNames | string]: number };
 
@@ -13,7 +17,7 @@ export class UpperBarManager {
   private readonly player: KalturaPlayer;
   private readonly logger: Logger;
   private readonly componentsRegistry: Map<number, IconModel>;
-  private readonly displayedBarComponentRef: RefObject<DisplayedBar>;
+  private readonly displayedBarComponentRefs: Record<string, RefObject<DisplayedBar>>;
   /**
    * @ignore
    */
@@ -21,7 +25,8 @@ export class UpperBarManager {
     this.player = player;
     this.componentsRegistry = new Map<number, IconModel>();
     this.logger = logger;
-    this.displayedBarComponentRef = createRef();
+    this.displayedBarComponentRefs = {};
+    relevantPresets.forEach((preset) => (this.displayedBarComponentRefs[preset] = createRef()));
     this.injectDisplayedBarComponentWrapper(config.pluginsIconsOrder);
   }
 
@@ -29,7 +34,9 @@ export class UpperBarManager {
     if (UpperBarManager.validateItem(icon)) {
       const newIcon: IconModel = new IconModel(icon);
       this.componentsRegistry.set(newIcon.id, newIcon);
-      this.displayedBarComponentRef.current!.update();
+      newIcon.presets.forEach((preset) => {
+        this.displayedBarComponentRefs[preset].current?.update();
+      });
       this.logger.debug(`Icon Id: '${newIcon.id}' '${newIcon.label}' added`);
       return newIcon.id;
     }
@@ -41,7 +48,9 @@ export class UpperBarManager {
     const icon: IconModel | undefined = this.componentsRegistry.get(itemId);
     if (icon) {
       this.componentsRegistry.delete(itemId);
-      this.displayedBarComponentRef.current!.update();
+      icon.presets.forEach((preset) => {
+        this.displayedBarComponentRefs[preset].current?.update();
+      });
       this.logger.debug(`Icon Id: '${icon.id}' Label: '${icon.label}' removed`);
     } else {
       this.logger.warn(`${itemId} is not registered`);
@@ -67,14 +76,21 @@ export class UpperBarManager {
   }
 
   private injectDisplayedBarComponentWrapper(iconsOrder: IconsOrder): void {
-    this.player.ui.addComponent({
-      label: 'Right-Upper-Bar-Wrapper',
-      presets: [ReservedPresetNames.Playback, ReservedPresetNames.Live, ReservedPresetNames.Img],
-      area: ReservedPresetAreas.TopBarRightControls,
-      get: () => {
-        return <DisplayedBar ref={this.displayedBarComponentRef} getControls={(): IconModel[] => this.getControls(iconsOrder)} />;
-      }
-    });
+    for (const preset of relevantPresets) {
+      this.player.ui.addComponent({
+        label: 'Right-Upper-Bar-Wrapper',
+        presets: [preset],
+        area: ReservedPresetAreas.TopBarRightControls,
+        get: () => {
+          return (
+            <DisplayedBar
+              ref={this.displayedBarComponentRefs[preset]}
+              getControls={(): IconModel[] => this.getControls(iconsOrder).filter((icon) => icon.presets.includes(preset))}
+            />
+          );
+        }
+      });
+    }
   }
 
   private static validateItem(icon: IconDto): boolean {

--- a/src/services/upper-bar-manager/upper-bar-manager.tsx
+++ b/src/services/upper-bar-manager/upper-bar-manager.tsx
@@ -6,7 +6,7 @@ import { DisplayedBar } from './ui/displayed-bar/displayed-bar.component';
 import { KalturaPluginNames } from '../../types/ui-managers-config';
 const { ReservedPresetAreas, ReservedPresetNames } = ui;
 
-const relevantPresets = Object.values(ReservedPresetNames).filter(
+const presets = Object.values(ReservedPresetNames).filter(
   (preset) => preset !== ReservedPresetNames.Idle && preset !== ReservedPresetNames.Error
 );
 
@@ -26,7 +26,7 @@ export class UpperBarManager {
     this.componentsRegistry = new Map<number, IconModel>();
     this.logger = logger;
     this.displayedBarComponentRefs = {};
-    relevantPresets.forEach((preset) => (this.displayedBarComponentRefs[preset] = createRef()));
+    presets.forEach((preset) => (this.displayedBarComponentRefs[preset] = createRef()));
     this.injectDisplayedBarComponentWrapper(config.pluginsIconsOrder);
   }
 
@@ -34,9 +34,7 @@ export class UpperBarManager {
     if (UpperBarManager.validateItem(icon)) {
       const newIcon: IconModel = new IconModel(icon);
       this.componentsRegistry.set(newIcon.id, newIcon);
-      newIcon.presets.forEach((preset) => {
-        this.displayedBarComponentRefs[preset].current?.update();
-      });
+      newIcon.presets.forEach((preset) => this.displayedBarComponentRefs[preset].current?.update());
       this.logger.debug(`Icon Id: '${newIcon.id}' '${newIcon.label}' added`);
       return newIcon.id;
     }
@@ -48,9 +46,7 @@ export class UpperBarManager {
     const icon: IconModel | undefined = this.componentsRegistry.get(itemId);
     if (icon) {
       this.componentsRegistry.delete(itemId);
-      icon.presets.forEach((preset) => {
-        this.displayedBarComponentRefs[preset].current?.update();
-      });
+      icon.presets.forEach((preset) => this.displayedBarComponentRefs[preset].current?.update());
       this.logger.debug(`Icon Id: '${icon.id}' Label: '${icon.label}' removed`);
     } else {
       this.logger.warn(`${itemId} is not registered`);
@@ -76,7 +72,7 @@ export class UpperBarManager {
   }
 
   private injectDisplayedBarComponentWrapper(iconsOrder: IconsOrder): void {
-    for (const preset of relevantPresets) {
+    for (const preset of presets) {
       this.player.ui.addComponent({
         label: 'Right-Upper-Bar-Wrapper',
         presets: [preset],

--- a/src/services/upper-bar-manager/upper-bar-manager.tsx
+++ b/src/services/upper-bar-manager/upper-bar-manager.tsx
@@ -6,7 +6,7 @@ import { DisplayedBar } from './ui/displayed-bar/displayed-bar.component';
 import { KalturaPluginNames } from '../../types/ui-managers-config';
 const { ReservedPresetAreas, ReservedPresetNames } = ui;
 
-const presets = Object.values(ReservedPresetNames).filter(
+const UPPER_BAR_PRESETS = Object.values(ReservedPresetNames).filter(
   (preset) => preset !== ReservedPresetNames.Idle && preset !== ReservedPresetNames.Error
 );
 
@@ -26,7 +26,7 @@ export class UpperBarManager {
     this.componentsRegistry = new Map<number, IconModel>();
     this.logger = logger;
     this.displayedBarComponentRefs = {};
-    presets.forEach((preset) => (this.displayedBarComponentRefs[preset] = createRef()));
+    UPPER_BAR_PRESETS.forEach((preset) => (this.displayedBarComponentRefs[preset] = createRef()));
     this.injectDisplayedBarComponentWrapper(config.pluginsIconsOrder);
   }
 
@@ -72,7 +72,7 @@ export class UpperBarManager {
   }
 
   private injectDisplayedBarComponentWrapper(iconsOrder: IconsOrder): void {
-    for (const preset of presets) {
+    for (const preset of UPPER_BAR_PRESETS) {
       this.player.ui.addComponent({
         label: 'Right-Upper-Bar-Wrapper',
         presets: [preset],

--- a/types/modules.d.ts
+++ b/types/modules.d.ts
@@ -1,3 +1,5 @@
+import { PlaykitUI } from "@playkit-js/kaltura-player-js";
+
 declare module "services/upper-bar-manager/models/svg-icon" {
     export interface SvgIcon {
         path: string;
@@ -35,6 +37,7 @@ declare module "services/upper-bar-manager/models/icon-dto" {
         component: ComponentClass<Record<string, never>> | FunctionalComponent<Record<string, never>>;
         svgIcon: SvgIcon;
         onClick: () => void;
+        presets?: PlaykitUI.ReservedPresetName[];
     }
 }
 declare module "services/upper-bar-manager/ui/icon-wrapper/icon-wrapper.component" {


### PR DESCRIPTION
### Description of the Changes

manage presets in upper-bar-manager.
each preset should have a `displayedBarWrapper` with icons.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
