### PR TITLE
feat(FEC-13515): change position and design of the toast comp

### DIFF
--- a/src/event-type/ui-managers-event.ts
+++ b/src/event-type/ui-managers-event.ts
@@ -1,0 +1,3 @@
+export const UiManagersEvent = {
+  UPDATE_COMPONENTS: 'UPDATE_COMPONENTS'
+};

--- a/src/services/floating-manager/floating-manager.tsx
+++ b/src/services/floating-manager/floating-manager.tsx
@@ -9,6 +9,7 @@ import { KalturaPlayer, PlaykitUI, Logger } from '@playkit-js/kaltura-player-js'
 
 import { FloatingItem } from './ui/floating-item';
 import { FloatingItemData, FloatingItemProps, FloatingPosition } from './models/floating-item-data';
+import { ToastEvent } from '../toast-manager/models';
 
 export interface FloatingManagerOptions {
   kalturaPlayer: KalturaPlayer;
@@ -201,5 +202,7 @@ export class FloatingManager {
       this._updateCachedCanvas();
       this._updateComponents();
     });
+
+    this._eventManager.listen(kalturaPlayer, ToastEvent.SHOW_TOAST, () => this._updateComponents());
   }
 }

--- a/src/services/floating-manager/floating-manager.tsx
+++ b/src/services/floating-manager/floating-manager.tsx
@@ -9,7 +9,7 @@ import { KalturaPlayer, PlaykitUI, Logger } from '@playkit-js/kaltura-player-js'
 
 import { FloatingItem } from './ui/floating-item';
 import { FloatingItemData, FloatingItemProps, FloatingPosition } from './models/floating-item-data';
-import { ToastEvent } from '../toast-manager/models';
+import { UiManagersEvent } from '../../event-type/ui-managers-event';
 
 export interface FloatingManagerOptions {
   kalturaPlayer: KalturaPlayer;
@@ -203,6 +203,6 @@ export class FloatingManager {
       this._updateComponents();
     });
 
-    this._eventManager.listen(kalturaPlayer, ToastEvent.SHOW_TOAST, () => this._updateComponents());
+    this._eventManager.listen(kalturaPlayer, UiManagersEvent.UPDATE_COMPONENTS, () => this._updateComponents());
   }
 }

--- a/src/services/toast-manager/models/index.ts
+++ b/src/services/toast-manager/models/index.ts
@@ -1,0 +1,5 @@
+import { ToastSeverity } from './toast-severity';
+import { ToastType } from './toast-type';
+import { ToastEvent } from './toast-event';
+
+export { ToastSeverity, ToastType, ToastEvent };

--- a/src/services/toast-manager/models/index.ts
+++ b/src/services/toast-manager/models/index.ts
@@ -1,5 +1,4 @@
 import { ToastSeverity } from './toast-severity';
 import { ToastType } from './toast-type';
-import { ToastEvent } from './toast-event';
 
-export { ToastSeverity, ToastType, ToastEvent };
+export { ToastSeverity, ToastType };

--- a/src/services/toast-manager/models/toast-event.ts
+++ b/src/services/toast-manager/models/toast-event.ts
@@ -1,0 +1,3 @@
+export const ToastEvent = {
+  SHOW_TOAST: 'SHOW_TOAST'
+};

--- a/src/services/toast-manager/models/toast-event.ts
+++ b/src/services/toast-manager/models/toast-event.ts
@@ -1,3 +1,0 @@
-export const ToastEvent = {
-  SHOW_TOAST: 'SHOW_TOAST'
-};

--- a/src/services/toast-manager/models/toast-type.ts
+++ b/src/services/toast-manager/models/toast-type.ts
@@ -1,0 +1,6 @@
+export enum ToastType {
+  TopRight = 'topRight',
+  TopLeft = 'topLeft',
+  BottomRight = 'bottomRight',
+  BottomLeft = 'bottomLeft'
+}

--- a/src/services/toast-manager/toast-manager.tsx
+++ b/src/services/toast-manager/toast-manager.tsx
@@ -8,12 +8,13 @@ import { FloatingItem } from '../floating-manager/ui/floating-item';
 
 import { ToastProps } from './ui/toast/toast';
 
-import { ToastSeverity } from './models/toast-severity';
+import { ToastSeverity, ToastType, ToastEvent } from './models';
 
 import { ToastsContainer } from './ui/toasts-container/toasts-container';
 
 export interface ToastManagerOptions {
   floatingManager: FloatingManager;
+  dispatchToastEvent: (event: string) => void;
 }
 
 export interface ToastItemData {
@@ -24,6 +25,7 @@ export interface ToastItemData {
   severity: ToastSeverity;
   duration: number;
   onClick: () => void;
+  toastType?: ToastType;
 }
 
 interface ManagedToasts {
@@ -37,14 +39,16 @@ export class ToastManager {
   private _options: ToastManagerOptions;
   private _toasts: ManagedToasts[] = [];
   private _floatingItem: FloatingItem | null = null;
+  private _dispatchToastEvent: (event: string) => void;
 
-  constructor(private options: ToastManagerOptions) {
+  constructor(private options: ToastManagerOptions, private dispatchToastEvent: (event: string) => void) {
     this._options = options;
+    this._dispatchToastEvent = dispatchToastEvent;
   }
 
   public add(data: ToastItemData): void {
-    const { duration, ...props } = data;
-    if (!this._floatingItem) this._addToastsContainer();
+    const { duration, toastType, ...props } = data;
+    if (!this._floatingItem) this._addToastsContainer(toastType);
     const managedToast = {
       toastProps: {
         ...props,
@@ -57,6 +61,7 @@ export class ToastManager {
     this._toasts.push(managedToast);
     this._updateToastsUI();
     this._startDurationTimer(managedToast);
+    this.dispatchToastEvent(ToastEvent.SHOW_TOAST);
   }
 
   public reset(): void {
@@ -81,7 +86,7 @@ export class ToastManager {
     if (this._toasts.length === 0) this._removeToastsContainer();
   };
 
-  private _addToastsContainer(): void {
+  private _addToastsContainer(toastType?: ToastType): void {
     this._floatingItem = this._options.floatingManager.add({
       label: 'Toasts',
       mode: 'Immediate',
@@ -89,6 +94,7 @@ export class ToastManager {
       renderContent: () => {
         return (
           <ToastsContainer
+            toastType={toastType}
             toasts={this._toasts.map((toast) => {
               return toast.toastProps;
             })}

--- a/src/services/toast-manager/toast-manager.tsx
+++ b/src/services/toast-manager/toast-manager.tsx
@@ -8,13 +8,14 @@ import { FloatingItem } from '../floating-manager/ui/floating-item';
 
 import { ToastProps } from './ui/toast/toast';
 
-import { ToastSeverity, ToastType, ToastEvent } from './models';
+import { ToastSeverity, ToastType } from './models';
 
 import { ToastsContainer } from './ui/toasts-container/toasts-container';
+import { UiManagersEvent } from '../../event-type/ui-managers-event';
 
 export interface ToastManagerOptions {
   floatingManager: FloatingManager;
-  dispatchToastEvent: (event: string) => void;
+  dispatchEvent: (event: string) => void;
 }
 
 export interface ToastItemData {
@@ -39,11 +40,11 @@ export class ToastManager {
   private _options: ToastManagerOptions;
   private _toasts: ManagedToasts[] = [];
   private _floatingItem: FloatingItem | null = null;
-  private _dispatchToastEvent: (event: string) => void;
+  private _dispatchEvent: (event: string) => void;
 
-  constructor(private options: ToastManagerOptions, private dispatchToastEvent: (event: string) => void) {
+  constructor(private options: ToastManagerOptions, private dispatchEvent: (event: string) => void) {
     this._options = options;
-    this._dispatchToastEvent = dispatchToastEvent;
+    this._dispatchEvent = dispatchEvent;
   }
 
   public add(data: ToastItemData): void {
@@ -61,7 +62,7 @@ export class ToastManager {
     this._toasts.push(managedToast);
     this._updateToastsUI();
     this._startDurationTimer(managedToast);
-    this.dispatchToastEvent(ToastEvent.SHOW_TOAST);
+    this.dispatchEvent(UiManagersEvent.UPDATE_COMPONENTS);
   }
 
   public reset(): void {
@@ -94,7 +95,7 @@ export class ToastManager {
       renderContent: () => {
         return (
           <ToastsContainer
-            toastType={toastType}
+            toastType={toastType || ToastType.BottomLeft}
             toasts={this._toasts.map((toast) => {
               return toast.toastProps;
             })}

--- a/src/services/toast-manager/ui/toast/toast.scss
+++ b/src/services/toast-manager/ui/toast/toast.scss
@@ -1,3 +1,5 @@
+@import '~@playkit-js/playkit-js-ui';
+
 .toastWrapper {
     position: relative;
     min-width: 120px;
@@ -6,26 +8,27 @@
     border-radius: 4px;
     background-color: #222222;
     border-left-style: solid;
-    border-left-width: 4px;
+    border-left-width: 2px;
     text-align: left;
+    padding: 8px;
   }
-  
+
   .infoToast {
-    border-left-color: #01ACCD;
+    border-left-color: $primary-color;
   }
-  
+
   .successToast {
-    border-left-color: #009E48;
+    border-left-color: $success-color;
   }
-  
+
   .warnToast {
-    border-left-color: #F9A71B;
+    border-left-color: $warning-color;
   }
-  
+
   .errorToast {
-    border-left-color: #E7585D;
+    border-left-color: $danger-color;
   }
-  
+
   .closeButton {
     position: absolute;
     background-color: transparent;
@@ -37,12 +40,14 @@
     background-repeat: no-repeat;
     border: none;
     padding: 0;
-  
+    margin-top: 8px;
+    margin-right: 8px;
+
     &:hover {
       cursor: pointer;
     }
   }
-  
+
   .title {
     font-size: 12px;
     font-weight: normal;
@@ -50,21 +55,21 @@
     font-stretch: normal;
     line-height: 1.17;
     letter-spacing: normal;
-    color: #cccccc;
+    color: $tone-1-color;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     padding-top: 4px;
     padding-right: 16px;
-    padding-left: 12px;
   }
-  
+
   .toastBody {
     position: relative;
     width: 100%;
-    padding: 2px 16px 5px 12px;
+    padding: 0px 16px 5px 0px;
+    margin-top: 8px;
   }
-  
+
   .iconContainer {
     position: relative;
     height: 16px;
@@ -72,12 +77,12 @@
     float: left;
     margin-right: 7px;
   }
-  
+
   .iconWrapper {
     height: 16px;
     width: 16px;
   }
-  
+
   .text {
     font-size: 14px;
     font-weight: bold;
@@ -85,10 +90,9 @@
     font-stretch: normal;
     line-height: normal;
     letter-spacing: normal;
-    color: #cccccc;
+    color: $tone-1-color;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
-  
-  
+

--- a/src/services/toast-manager/ui/toast/toast.tsx
+++ b/src/services/toast-manager/ui/toast/toast.tsx
@@ -1,6 +1,6 @@
 import { Component, h } from 'preact';
 import * as styles from './toast.scss';
-import { ToastSeverity } from '../../models/toast-severity';
+import { ToastSeverity } from '../../models';
 import { Icon, IconSize } from '@playkit-js/common/dist/icon';
 
 export interface ToastProps {

--- a/src/services/toast-manager/ui/toasts-container/toasts-container.scss
+++ b/src/services/toast-manager/ui/toasts-container/toasts-container.scss
@@ -1,19 +1,39 @@
 .toastsContainer {
     position: absolute;
-    right: 0;
-    top: 0;
-    padding: 8px 16px 0;
     min-width: 120px;
     max-width: 310px;
     display: flex;
     flex-direction: column;
+    z-index: 2;
+    &.top-right {
+        right: 0;
+        top: 0;
+    }
+    &.top-left {
+        left: 0;
+        top: 0;
+        .toastRow {
+            align-self: flex-start;
+        }
+    }
+    &.bottom-right {
+        right: 0;
+        bottom: 0;
+    }
+    &.bottom-left {
+        left: 0;
+        bottom: 0;
+        .toastRow {
+            align-self: flex-start;
+        }
+    }
 }
 
 .toastRow {
-    height: 42px;
+    height: 58px;
     min-width: 120px;
     max-width: 310px;
-    margin-bottom: 8px;
+    margin-top: 8px;
     overflow: hidden;
     overflow-wrap: break-word;
     text-overflow: ellipsis;

--- a/src/services/toast-manager/ui/toasts-container/toasts-container.tsx
+++ b/src/services/toast-manager/ui/toasts-container/toasts-container.tsx
@@ -2,15 +2,18 @@ import { Component, h } from 'preact';
 import { Toast, ToastProps } from '../toast/toast';
 
 import * as styles from './toasts-container.scss';
+import { ToastType } from '../../models';
 
 export interface ToastsContainerProps {
   toasts: ToastProps[];
+  toastType?: ToastType;
 }
 
 export class ToastsContainer extends Component<ToastsContainerProps> {
   render() {
+    const className = [styles.toastsContainer, styles[`${this.props.toastType || ToastType.BottomLeft}`]];
     return (
-      <div className={styles.toastsContainer} aria-live="polite">
+      <div className={className.join(' ')} aria-live="polite">
         {this.props.toasts.map((toast) => {
           return (
             <div className={styles.toastRow} key={toast.id}>

--- a/src/ui-managers.ts
+++ b/src/ui-managers.ts
@@ -45,7 +45,9 @@ export class UIManagers extends BasePlugin<UiManagerConfig> {
       eventManager: this.eventManager
     });
     player.registerService('floatingManager', floatingManager);
-    player.registerService('toastManager', new ToastManager({ floatingManager }));
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    player.registerService('toastManager', new ToastManager({ floatingManager }, (event: string) => this.dispatchEvent(event)));
     player.registerService('bannerManager', new BannerManager({ floatingManager, kalturaPlayer: player }));
   }
 

--- a/types/modules.d.ts
+++ b/types/modules.d.ts
@@ -404,27 +404,10 @@ declare module "services/floating-manager/ui/floating-item" {
         private _addPlayerBindings;
     }
 }
-declare module "services/toast-manager/models/toast-severity" {
-    export type ToastSeverity = 'Info' | 'Success' | 'Warning' | 'Error';
-}
-declare module "services/toast-manager/models/toast-type" {
-    export enum ToastType {
-        TopRight = "topRight",
-        TopLeft = "topLeft",
-        BottomRight = "bottomRight",
-        BottomLeft = "bottomLeft"
-    }
-}
-declare module "services/toast-manager/models/toast-event" {
-    export const ToastEvent: {
-        SHOW_TOAST: string;
+declare module "event-type/ui-managers-event" {
+    export const UiManagersEvent: {
+        UPDATE_COMPONENTS: string;
     };
-}
-declare module "services/toast-manager/models/index" {
-    import { ToastSeverity } from "services/toast-manager/models/toast-severity";
-    import { ToastType } from "services/toast-manager/models/toast-type";
-    import { ToastEvent } from "services/toast-manager/models/toast-event";
-    export { ToastSeverity, ToastType, ToastEvent };
 }
 declare module "services/floating-manager/floating-manager" {
     import { PresetManager } from "services/preset-manager/preset-manager";
@@ -463,6 +446,22 @@ declare module "services/floating-manager/floating-manager" {
         private _onLoadedData;
         private _addPlayerBindings;
     }
+}
+declare module "services/toast-manager/models/toast-severity" {
+    export type ToastSeverity = 'Info' | 'Success' | 'Warning' | 'Error';
+}
+declare module "services/toast-manager/models/toast-type" {
+    export enum ToastType {
+        TopRight = "topRight",
+        TopLeft = "topLeft",
+        BottomRight = "bottomRight",
+        BottomLeft = "bottomLeft"
+    }
+}
+declare module "services/toast-manager/models/index" {
+    import { ToastSeverity } from "services/toast-manager/models/toast-severity";
+    import { ToastType } from "services/toast-manager/models/toast-type";
+    export { ToastSeverity, ToastType };
 }
 declare module "services/toast-manager/ui/toast/toast" {
     import { Component, h } from 'preact';
@@ -506,7 +505,7 @@ declare module "services/toast-manager/toast-manager" {
     import { ToastSeverity, ToastType } from "services/toast-manager/models/index";
     export interface ToastManagerOptions {
         floatingManager: FloatingManager;
-        dispatchToastEvent: (event: string) => void;
+        dispatchEvent: (event: string) => void;
     }
     export interface ToastItemData {
         title: string;
@@ -519,12 +518,12 @@ declare module "services/toast-manager/toast-manager" {
     }
     export class ToastManager {
         private options;
-        private dispatchToastEvent;
+        private dispatchEvent;
         private _options;
         private _toasts;
         private _floatingItem;
-        private _dispatchToastEvent;
-        constructor(options: ToastManagerOptions, dispatchToastEvent: (event: string) => void);
+        private _dispatchEvent;
+        constructor(options: ToastManagerOptions, dispatchEvent: (event: string) => void);
         add(data: ToastItemData): void;
         reset(): void;
         private _startDurationTimer;

--- a/types/modules.d.ts
+++ b/types/modules.d.ts
@@ -445,6 +445,9 @@ declare module "services/floating-manager/floating-manager" {
 declare module "services/toast-manager/models/toast-severity" {
     export type ToastSeverity = 'Info' | 'Success' | 'Warning' | 'Error';
 }
+declare module "services/toast-manager/models/toast-type" {
+    export enum ToastType { TopRight = 'topRight', TopLeft = 'topLeft', BottomRight = 'bottomRight', BottomLeft = 'bottomLeft' }
+}
 declare module "services/toast-manager/ui/toast/toast" {
     import { Component, h } from 'preact';
     import { ToastSeverity } from "services/toast-manager/models/toast-severity";
@@ -483,6 +486,7 @@ declare module "services/toast-manager/ui/toasts-container/toasts-container" {
 declare module "services/toast-manager/toast-manager" {
     import { FloatingManager } from "services/floating-manager/floating-manager";
     import { ToastSeverity } from "services/toast-manager/models/toast-severity";
+    import { ToastType } from "services/toast-manager/models/toast-type";
     export interface ToastManagerOptions {
         floatingManager: FloatingManager;
     }
@@ -493,6 +497,7 @@ declare module "services/toast-manager/toast-manager" {
         severity: ToastSeverity;
         duration: number;
         onClick: () => void;
+        toastType?: ToastType;
     }
     export class ToastManager {
         private options;

--- a/types/modules.d.ts
+++ b/types/modules.d.ts
@@ -404,6 +404,28 @@ declare module "services/floating-manager/ui/floating-item" {
         private _addPlayerBindings;
     }
 }
+declare module "services/toast-manager/models/toast-severity" {
+    export type ToastSeverity = 'Info' | 'Success' | 'Warning' | 'Error';
+}
+declare module "services/toast-manager/models/toast-type" {
+    export enum ToastType {
+        TopRight = "topRight",
+        TopLeft = "topLeft",
+        BottomRight = "bottomRight",
+        BottomLeft = "bottomLeft"
+    }
+}
+declare module "services/toast-manager/models/toast-event" {
+    export const ToastEvent: {
+        SHOW_TOAST: string;
+    };
+}
+declare module "services/toast-manager/models/index" {
+    import { ToastSeverity } from "services/toast-manager/models/toast-severity";
+    import { ToastType } from "services/toast-manager/models/toast-type";
+    import { ToastEvent } from "services/toast-manager/models/toast-event";
+    export { ToastSeverity, ToastType, ToastEvent };
+}
 declare module "services/floating-manager/floating-manager" {
     import { PresetManager } from "services/preset-manager/preset-manager";
     import { KalturaPlayer, PlaykitUI, Logger } from '@playkit-js/kaltura-player-js';
@@ -442,15 +464,9 @@ declare module "services/floating-manager/floating-manager" {
         private _addPlayerBindings;
     }
 }
-declare module "services/toast-manager/models/toast-severity" {
-    export type ToastSeverity = 'Info' | 'Success' | 'Warning' | 'Error';
-}
-declare module "services/toast-manager/models/toast-type" {
-    export enum ToastType { TopRight = 'topRight', TopLeft = 'topLeft', BottomRight = 'bottomRight', BottomLeft = 'bottomLeft' }
-}
 declare module "services/toast-manager/ui/toast/toast" {
     import { Component, h } from 'preact';
-    import { ToastSeverity } from "services/toast-manager/models/toast-severity";
+    import { ToastSeverity } from "services/toast-manager/models/index";
     export interface ToastProps {
         id: string;
         title: string;
@@ -476,8 +492,10 @@ declare module "services/toast-manager/ui/toast/toast" {
 declare module "services/toast-manager/ui/toasts-container/toasts-container" {
     import { Component, h } from 'preact';
     import { ToastProps } from "services/toast-manager/ui/toast/toast";
+    import { ToastType } from "services/toast-manager/models/index";
     export interface ToastsContainerProps {
         toasts: ToastProps[];
+        toastType?: ToastType;
     }
     export class ToastsContainer extends Component<ToastsContainerProps> {
         render(): h.JSX.Element;
@@ -485,10 +503,10 @@ declare module "services/toast-manager/ui/toasts-container/toasts-container" {
 }
 declare module "services/toast-manager/toast-manager" {
     import { FloatingManager } from "services/floating-manager/floating-manager";
-    import { ToastSeverity } from "services/toast-manager/models/toast-severity";
-    import { ToastType } from "services/toast-manager/models/toast-type";
+    import { ToastSeverity, ToastType } from "services/toast-manager/models/index";
     export interface ToastManagerOptions {
         floatingManager: FloatingManager;
+        dispatchToastEvent: (event: string) => void;
     }
     export interface ToastItemData {
         title: string;
@@ -501,10 +519,12 @@ declare module "services/toast-manager/toast-manager" {
     }
     export class ToastManager {
         private options;
+        private dispatchToastEvent;
         private _options;
         private _toasts;
         private _floatingItem;
-        constructor(options: ToastManagerOptions);
+        private _dispatchToastEvent;
+        constructor(options: ToastManagerOptions, dispatchToastEvent: (event: string) => void);
         add(data: ToastItemData): void;
         reset(): void;
         private _startDurationTimer;


### PR DESCRIPTION
### Description of the Changes

- change the default position of a toast to be at the bottom-left side
- add the ability to configure the position of a toast (via the add API)
- align the toast appearance with the design
- make the toast show immediately when it is being added

Solves FEC-13515

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
