### PR TITLE
 fix(FEC-13889): Remove unused and redundant & error prone onActivate & onDecativate callback params from SidePaneItem Interface

### DIFF
--- a/demo/side-panels-manager/some-plugin.js
+++ b/demo/side-panels-manager/some-plugin.js
@@ -30,12 +30,6 @@ export class somePlugin extends BasePlugin {
         presets: [ReservedPresetNames.Playback, ReservedPresetNames.Live],
         position: SidePanelPositions.LEFT,
         expandMode: SidePanelModes.ALONGSIDE,
-        onActivate: () => {
-          console.log('panel has now been activated');
-        },
-        onDeactivate: () => {
-          console.log('panel has now been deactivated');
-        }
       });
 
       this.addUpperBarIcon('Panel-A', panelItemAId, IconComponent);

--- a/src/services/side-panels-manager/models/item-wrapper.tsx
+++ b/src/services/side-panels-manager/models/item-wrapper.tsx
@@ -27,7 +27,6 @@ export class ItemWrapper {
   public activate(): void {
     if (this.panelItemComponentRef.current) {
       this.panelItemComponentRef.current!.on();
-      this.item.onActivate?.();
       this.isActive = true;
     } else {
       setTimeout(() => this.activate());
@@ -36,7 +35,6 @@ export class ItemWrapper {
 
   public deactivate(switchMode = false): void {
     this.panelItemComponentRef.current!.off(switchMode);
-    this.item.onDeactivate?.();
     this.isActive = false;
   }
 

--- a/src/services/side-panels-manager/models/side-panel-item.ts
+++ b/src/services/side-panels-manager/models/side-panel-item.ts
@@ -11,6 +11,4 @@ export interface SidePanelItem {
   readonly presets: PlaykitUI.ReservedPresetName[];
   readonly position: PlaykitUI.SidePanelPosition;
   readonly expandMode: PlaykitUI.SidePanelMode;
-  readonly onActivate?: () => void;
-  readonly onDeactivate?: () => void;
 }

--- a/src/services/side-panels-manager/side-panels-manager.ts
+++ b/src/services/side-panels-manager/side-panels-manager.ts
@@ -149,15 +149,13 @@ export class SidePanelsManager {
   }
 
   private static validateItem(item: SidePanelItem): boolean {
-    const { label, panelComponent, position, expandMode, onActivate, onDeactivate, presets } = item;
+    const { label, panelComponent, position, expandMode, presets } = item;
     return !!(
       label &&
       Object.values(SidePanelPositions).includes(position) &&
       Object.values(SidePanelModes).includes(expandMode) &&
       presets.every((preset) => Object.values(ReservedPresetNames).includes(preset)) &&
-      typeof panelComponent === 'function' &&
-      (typeof onActivate === 'function' || onActivate === undefined) &&
-      (typeof onDeactivate === 'function' || onDeactivate === undefined)
+      typeof panelComponent === 'function'
     );
   }
 }


### PR DESCRIPTION
### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
### Resolves: [FEC-13889](https://kaltura.atlassian.net/browse/FEC-13889)

#### Related PRs:
https://github.com/kaltura/playkit-js-transcript/pull/192
https://github.com/kaltura/playkit-js-qna/pull/342
https://github.com/kaltura/playkit-js-navigation/pull/360

[FEC-13889]: https://kaltura.atlassian.net/browse/FEC-13889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ