### PR TITLE
fix(FEC-13709): remove player top bar if there is no content in it

### DIFF
--- a/src/services/upper-bar-manager/ui/displayed-bar/displayed-bar.component.tsx
+++ b/src/services/upper-bar-manager/ui/displayed-bar/displayed-bar.component.tsx
@@ -83,7 +83,7 @@ export class DisplayedBar extends Component<DisplayedBarProps & PropsFromRedux, 
 
   render(): ComponentChild {
     const { displayedControls, dropdownControls } = this.splitControlsIntoDisplayedAndDropdown();
-    return (
+    return displayedControls.length > 0 ? (
       <div className={styles.rightUpperBarWrapperContainer}>
         {displayedControls.map(({ id, component, onClick, componentRef }) => {
           const IconWrapperComponent = component!;
@@ -104,6 +104,6 @@ export class DisplayedBar extends Component<DisplayedBarProps & PropsFromRedux, 
           <MoreIcon showDropdown={this.state.showDropdown} onClick={this.handleOnClick} icons={dropdownControls} />
         )}
       </div>
-    );
+    ) : undefined;
   }
 }


### PR DESCRIPTION
### Description of the Changes

- bugfix.

do not render the `DisplayedBarComponentWrapper` root element in case there are no components to render within.

related PR: https://github.com/kaltura/playkit-js-ui/pull/883

Solves FEC-13709

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
