### PR TITLE
fix(FEC-13991): handle initial size of detach window

### DIFF
--- a/src/services/side-panels-manager/models/item-wrapper.tsx
+++ b/src/services/side-panels-manager/models/item-wrapper.tsx
@@ -44,6 +44,7 @@ export class ItemWrapper {
   private _detachWindowPosition = { screenX: 0, screenY: 0 };
   private _detachWindowSize = { innerWidth: 0, innerHeight: 0 };
   private _detachWindowAnalyticsInterval: ReturnType<typeof setInterval> | null = null;
+  private _initialDetachWindowSizeSet = false;
 
   constructor(item: SidePanelItem, player: KalturaPlayer) {
     this.id = ++ItemWrapper.nextId;
@@ -126,11 +127,13 @@ export class ItemWrapper {
     if (options.onDetachMove || options.onDetachResize) {
       const { screenX, screenY } = this._detachWindow!;
       this._setDetachWindowPosition(screenX, screenY);
-      const { innerWidth, innerHeight } = this._detachWindow!;
-      this._setDetachWindowSize(innerWidth, innerHeight);
 
       // use interval since there no handlers for new window position change
       this._detachWindowAnalyticsInterval = setInterval(() => {
+        if (!this._initialDetachWindowSizeSet) {
+          this._setDetachWindowSize(this._detachWindow!.innerWidth, this._detachWindow!.innerHeight);
+          this._initialDetachWindowSizeSet = true;
+        }
         if (
           options.onDetachMove &&
           (this._detachWindow!.screenX !== this._detachWindowPosition.screenX ||
@@ -198,6 +201,7 @@ export class ItemWrapper {
     this._detachWindow = null;
     this._closingDetachWindow = false;
     this._attachingDetachWindow = false;
+    this._initialDetachWindowSizeSet = false;
     this._setDetachWindowPosition(0, 0);
     this._setDetachWindowSize(0, 0);
     if (this._detachWindowAnalyticsInterval) {


### PR DESCRIPTION
### Description of the Changes

New window auto-resizes to content size. The changes prevents send initial size of the new window as resize event.

resolves: https://kaltura.atlassian.net/browse/FEC-13991

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
