### PR TITLE
feat(FEC-13945): move core controls to upper bar

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -55,7 +55,15 @@ module.exports = function (config) {
     // enable / disable watching file and executing tests whenever any file changes
     autoWatch: false,
 
-    // start these browsers
+    // custom browser launcher - chrome with flags
+    customLaunchers: {
+      ChromeWithFlags: {
+        base: 'Chrome',
+        flags: ['--no-sandbox', '--autoplay-policy=no-user-gesture-required', '--mute-audio', '--max-web-media-player-count=1000']
+      }
+    },
+
+    // start these browsers by default
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: ['ChromeHeadless'],
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build": "webpack --mode production",
     "test": "karma start --color --mode development",
     "test:debug": "DEBUG_UNIT_TESTS=1 karma start karma.conf.js --auto-watch --no-single-run --browsers Chrome",
-    "test:watch": "karma start karma.conf.js --auto-watch --no-single-run",
+    "test:watch": "karma start karma.conf.js --auto-watch --no-single-run --browsers ChromeWithFlags",
     "types:check": "tsc src/index.ts src/types/global.d.ts --jsx react --jsxFactory h --noEmit --target ESNext --moduleResolution node --experimentalDecorators --jsxFragmentFactory Fragment",
     "types:generate": "tsc src/index.ts src/types/global.d.ts --declaration --emitDeclarationOnly --outFile types/modules.ts --jsx react --jsxFactory h --jsxFragmentFactory Fragment --stripInternal true --target ESNext --moduleResolution node --experimentalDecorators",
     "docs:generate": "typedoc",

--- a/src/services/side-panels-manager/models/item-wrapper.tsx
+++ b/src/services/side-panels-manager/models/item-wrapper.tsx
@@ -64,7 +64,7 @@ export class ItemWrapper {
   }
 
   public deactivate(switchMode = false): void {
-    this.panelItemComponentRef.current!.off(switchMode);
+    this.panelItemComponentRef.current?.off(switchMode);
     this.isActive = false;
   }
 
@@ -178,7 +178,7 @@ export class ItemWrapper {
   }
 
   public update(): void {
-    this.panelItemComponentRef.current!.forceUpdate();
+    this.panelItemComponentRef.current?.forceUpdate();
   }
 
   private _setDetachWindowPosition = (x: number, y: number) => {

--- a/src/services/upper-bar-manager/models/icon-dto.ts
+++ b/src/services/upper-bar-manager/models/icon-dto.ts
@@ -22,7 +22,7 @@ export interface IconDto {
   /**
    * Icon that will appear in the dropdown menu
    */
-  svgIcon: SvgIcon;
+  svgIcon: SvgIcon | (() => SvgIcon);
   /**
    * The icon handler
    *
@@ -35,4 +35,8 @@ export interface IconDto {
    * Relevant presets for the icon
    */
   presets?: PlaykitUI.ReservedPresetName[];
+  /**
+   * An indication whether the component can manage itself or not
+   */
+  selfManagement?: boolean;
 }

--- a/src/services/upper-bar-manager/models/icon-dto.ts
+++ b/src/services/upper-bar-manager/models/icon-dto.ts
@@ -36,7 +36,7 @@ export interface IconDto {
    */
   presets?: PlaykitUI.ReservedPresetName[];
   /**
-   * An indication whether the component can manage itself or not
+   * An indication whether the upper bar should handle the onClick callback of the component or not
    */
-  selfManagement?: boolean;
+  shouldHandleOnClick?: boolean;
 }

--- a/src/services/upper-bar-manager/models/icon-model.ts
+++ b/src/services/upper-bar-manager/models/icon-model.ts
@@ -30,6 +30,6 @@ export class IconModel {
   }
 
   public update(): void {
-    this.componentRef.current!.forceUpdate();
+    this.componentRef.current?.forceUpdate();
   }
 }

--- a/src/services/upper-bar-manager/models/icon-model.ts
+++ b/src/services/upper-bar-manager/models/icon-model.ts
@@ -16,7 +16,7 @@ export class IconModel {
   public component: ComponentClass<Record<string, never>> | FunctionalComponent<Record<string, never>>;
   public svgIcon: SvgIcon | (() => SvgIcon);
   public presets: PlaykitUI.ReservedPresetName[];
-  public selfManagement: boolean;
+  public shouldHandleOnClick: boolean;
   constructor(item: IconDto) {
     this.id = ++IconModel.nextId;
     this.displayName = item.displayName;
@@ -28,7 +28,7 @@ export class IconModel {
     this.componentRef = createRef();
     this.presets =
       item.presets && item.presets.length > 0 ? item.presets : [ReservedPresetNames.Playback, ReservedPresetNames.Live];
-    this.selfManagement = item.selfManagement || false;
+    this.shouldHandleOnClick = typeof item.shouldHandleOnClick === 'boolean' ? item.shouldHandleOnClick : true;
   }
 
   public update(): void {

--- a/src/services/upper-bar-manager/models/icon-model.ts
+++ b/src/services/upper-bar-manager/models/icon-model.ts
@@ -14,8 +14,9 @@ export class IconModel {
   public componentRef: RefObject<IconWrapper>;
   public onClick: (e: MouseEvent | KeyboardEvent) => void;
   public component: ComponentClass<Record<string, never>> | FunctionalComponent<Record<string, never>>;
-  public svgIcon: SvgIcon;
+  public svgIcon: SvgIcon | (() => SvgIcon);
   public presets: PlaykitUI.ReservedPresetName[];
+  public selfManagement: boolean;
   constructor(item: IconDto) {
     this.id = ++IconModel.nextId;
     this.displayName = item.displayName;
@@ -27,6 +28,7 @@ export class IconModel {
     this.componentRef = createRef();
     this.presets =
       item.presets && item.presets.length > 0 ? item.presets : [ReservedPresetNames.Playback, ReservedPresetNames.Live];
+    this.selfManagement = item.selfManagement || false;
   }
 
   public update(): void {

--- a/src/services/upper-bar-manager/move-controls-manager.ts
+++ b/src/services/upper-bar-manager/move-controls-manager.ts
@@ -43,7 +43,7 @@ export class MoveControlsManager {
       if (controlsToMove.length > 0) {
         this.logger.debug('Adding core controls to upper bar: ', controlsToMove);
         controlsToMove.forEach((componentName: string) => {
-          const componentToMove: IconDto = bottomBarRegistryManager.registry.get(componentName);
+          const componentToMove: IconDto = bottomBarRegistryManager.getComponentItem(componentName);
           if (componentToMove) {
             const iconId = this.upperBarManager.add(componentToMove);
             if (typeof iconId === 'number') {

--- a/src/services/upper-bar-manager/move-controls-manager.ts
+++ b/src/services/upper-bar-manager/move-controls-manager.ts
@@ -1,0 +1,58 @@
+import { KalturaPlayer, Logger, ui } from '@playkit-js/kaltura-player-js';
+import { UpperBarManager } from './upper-bar-manager';
+import { IconDto } from './models/icon-dto';
+
+const { redux } = ui;
+
+export class MoveControlsManager {
+  private readonly player: KalturaPlayer;
+  private readonly logger: Logger;
+  private store: any;
+  private upperBarManager: UpperBarManager;
+  private currentState: any;
+  private iconIds: Map<string, number>;
+
+  constructor(player: KalturaPlayer, logger: Logger, upperBarManager: UpperBarManager) {
+    this.player = player;
+    this.logger = logger;
+    this.store = redux.useStore();
+    this.upperBarManager = upperBarManager;
+    this.store.subscribe(this.handleStoreChange.bind(this));
+    this.currentState = this.store.getState();
+    this.iconIds = new Map();
+  }
+
+  private get bottomBarRegistryManager(): any {
+    return (this.player.getService('bottomBarRegistryManager') as any) || undefined;
+  }
+
+  private get state(): any {
+    return this.store.getState();
+  }
+
+  private handleStoreChange(): void {
+    const newState = this.state;
+    const bottomBarRegistryManager = this.bottomBarRegistryManager;
+    if (bottomBarRegistryManager && this.currentState.bottomBar !== newState.bottomBar) {
+      this.logger.debug('Removing core controls from upper bar');
+      // remove all the core icons and clear map
+      [...this.iconIds.values()].forEach((iconId) => this.upperBarManager.remove(iconId));
+      this.iconIds.clear();
+
+      const { controlsToMove } = newState.bottomBar;
+      if (controlsToMove.length > 0) {
+        this.logger.debug('Adding core controls to upper bar: ', controlsToMove);
+        controlsToMove.forEach((compName: string) => {
+          const comp: IconDto = bottomBarRegistryManager.registry.get(compName);
+          if (comp) {
+            const iconId = this.upperBarManager.add(comp);
+            if (typeof iconId === 'number') {
+              this.iconIds.set(compName, iconId);
+            }
+          }
+        });
+      }
+      this.currentState = newState;
+    }
+  }
+}

--- a/src/services/upper-bar-manager/move-controls-manager.ts
+++ b/src/services/upper-bar-manager/move-controls-manager.ts
@@ -42,12 +42,12 @@ export class MoveControlsManager {
       const { controlsToMove } = newState.bottomBar;
       if (controlsToMove.length > 0) {
         this.logger.debug('Adding core controls to upper bar: ', controlsToMove);
-        controlsToMove.forEach((compName: string) => {
-          const comp: IconDto = bottomBarRegistryManager.registry.get(compName);
-          if (comp) {
-            const iconId = this.upperBarManager.add(comp);
+        controlsToMove.forEach((componentName: string) => {
+          const componentToMove: IconDto = bottomBarRegistryManager.registry.get(componentName);
+          if (componentToMove) {
+            const iconId = this.upperBarManager.add(componentToMove);
             if (typeof iconId === 'number') {
-              this.iconIds.set(compName, iconId);
+              this.iconIds.set(componentName, iconId);
             }
           }
         });

--- a/src/services/upper-bar-manager/move-controls-manager.ts
+++ b/src/services/upper-bar-manager/move-controls-manager.ts
@@ -1,8 +1,6 @@
-import { KalturaPlayer, Logger, ui } from '@playkit-js/kaltura-player-js';
+import { KalturaPlayer, Logger } from '@playkit-js/kaltura-player-js';
 import { UpperBarManager } from './upper-bar-manager';
 import { IconDto } from './models/icon-dto';
-
-const { redux } = ui;
 
 export class MoveControlsManager {
   private readonly player: KalturaPlayer;
@@ -12,7 +10,7 @@ export class MoveControlsManager {
   private currentState: any;
   private iconIds: Map<string, number>;
 
-  constructor(player: KalturaPlayer, logger: Logger, upperBarManager: UpperBarManager) {
+  constructor(player: KalturaPlayer, logger: Logger, upperBarManager: UpperBarManager, redux: any) {
     this.player = player;
     this.logger = logger;
     this.store = redux.useStore();

--- a/src/services/upper-bar-manager/ui/displayed-bar/displayed-bar.component.scss
+++ b/src/services/upper-bar-manager/ui/displayed-bar/displayed-bar.component.scss
@@ -1,4 +1,5 @@
 .right-upper-bar-wrapper-container {
   direction: ltr;
   display: flex;
+  align-items: center;
 }

--- a/src/services/upper-bar-manager/ui/displayed-bar/displayed-bar.component.tsx
+++ b/src/services/upper-bar-manager/ui/displayed-bar/displayed-bar.component.tsx
@@ -86,13 +86,13 @@ export class DisplayedBar extends Component<DisplayedBarProps & PropsFromRedux, 
     const { displayedControls, dropdownControls } = this.splitControlsIntoDisplayedAndDropdown();
     return displayedControls.length > 0 ? (
       <div className={styles.rightUpperBarWrapperContainer}>
-        {displayedControls.map(({ id, component, onClick, componentRef, selfManagement }) => {
+        {displayedControls.map(({ id, component, onClick, componentRef, shouldHandleOnClick }) => {
           const IconWrapperComponent = component!;
           return (
             <IconWrapper
               key={id}
               onClick={(...e): void => {
-                if (!selfManagement) {
+                if (shouldHandleOnClick) {
                   onClick(...e);
                 }
                 this.closeDropdown();

--- a/src/services/upper-bar-manager/ui/displayed-bar/displayed-bar.component.tsx
+++ b/src/services/upper-bar-manager/ui/displayed-bar/displayed-bar.component.tsx
@@ -2,7 +2,7 @@ import { h, Component, ComponentChild, RefObject } from 'preact';
 import { IconModel } from '../../models/icon-model';
 import { IconWrapper } from '../icon-wrapper/icon-wrapper.component';
 import * as styles from './displayed-bar.component.scss';
-import { ui } from '@playkit-js/kaltura-player-js';
+import { KalturaPlayer, ui } from '@playkit-js/kaltura-player-js';
 import { MoreIcon } from '../more-icon/more-icon.component';
 
 const { PLAYER_SIZE } = ui.Components;
@@ -22,6 +22,7 @@ type DisplayedBarState = {
 type DisplayedBarProps = {
   getControls: () => IconModel[];
   ref: RefObject<DisplayedBar>;
+  player: KalturaPlayer;
 };
 type PropsFromRedux = {
   playerSize?: string;
@@ -85,13 +86,15 @@ export class DisplayedBar extends Component<DisplayedBarProps & PropsFromRedux, 
     const { displayedControls, dropdownControls } = this.splitControlsIntoDisplayedAndDropdown();
     return displayedControls.length > 0 ? (
       <div className={styles.rightUpperBarWrapperContainer}>
-        {displayedControls.map(({ id, component, onClick, componentRef }) => {
+        {displayedControls.map(({ id, component, onClick, componentRef, selfManagement }) => {
           const IconWrapperComponent = component!;
           return (
             <IconWrapper
               key={id}
               onClick={(...e): void => {
-                onClick(...e);
+                if (!selfManagement) {
+                  onClick(...e);
+                }
                 this.closeDropdown();
               }}
               ref={componentRef}
@@ -101,7 +104,12 @@ export class DisplayedBar extends Component<DisplayedBarProps & PropsFromRedux, 
           );
         })}
         {dropdownControls.length > 0 && (
-          <MoreIcon showDropdown={this.state.showDropdown} onClick={this.handleOnClick} icons={dropdownControls} />
+          <MoreIcon
+            showDropdown={this.state.showDropdown}
+            onClick={this.handleOnClick}
+            icons={dropdownControls}
+            player={this.props.player}
+          />
         )}
       </div>
     ) : undefined;

--- a/src/services/upper-bar-manager/ui/dropdown-bar-item/dropdown-bar-item.scss
+++ b/src/services/upper-bar-manager/ui/dropdown-bar-item/dropdown-bar-item.scss
@@ -1,0 +1,47 @@
+@import '~@playkit-js/playkit-js-ui';
+
+.dropdown-item {
+  border-radius: 4px;
+  padding: 4px 12px 4px 15px;
+  display: flex;
+  margin: 4px 0;
+  cursor: pointer;
+  align-items: center;
+
+  .icon {
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    i {
+      display: inline-block;
+    }
+  }
+
+  &:hover {
+    background-color: $tone-6-color;
+  }
+
+  .dropdown-item-description {
+    flex: 1;
+    font-size: 14px;
+    font-weight: 700;
+    padding-left: 11px;
+    overflow: hidden;
+    white-space: nowrap;
+
+    &.trim-text {
+      text-overflow: ellipsis;
+    }
+  }
+
+  .comparison-text {
+    position: absolute;
+    font-size: 14px;
+    font-weight: 700;
+    left: 0;
+    padding: 0;
+  }
+}

--- a/src/services/upper-bar-manager/ui/dropdown-bar-item/dropdown-bar-item.scss
+++ b/src/services/upper-bar-manager/ui/dropdown-bar-item/dropdown-bar-item.scss
@@ -45,3 +45,7 @@
     padding: 0;
   }
 }
+
+.more-item-tooltip {
+  z-index: 1;
+}

--- a/src/services/upper-bar-manager/ui/dropdown-bar-item/dropdown-bar-item.tsx
+++ b/src/services/upper-bar-manager/ui/dropdown-bar-item/dropdown-bar-item.tsx
@@ -1,0 +1,80 @@
+import { h, Fragment, VNode } from 'preact';
+import { useState, useRef, useLayoutEffect } from 'preact/hooks';
+import * as styles from './dropdown-bar-item.scss';
+import { ui } from '@playkit-js/kaltura-player-js';
+import { A11yWrapper } from '@playkit-js/common/dist/hoc/a11y-wrapper';
+import { SvgIcon } from '../../models/svg-icon';
+const { Icon, Tooltip } = ui.Components;
+
+type DropdownBarItemProps = {
+  displayName: string;
+  text: string;
+  icon: SvgIcon;
+  onClick: (e: KeyboardEvent | MouseEvent) => void;
+  onDropdownClick: () => void;
+};
+
+const PADDING = 11;
+
+const DropdownBarItem = ({ displayName, text, icon, onClick, onDropdownClick }: DropdownBarItemProps) => {
+  const comparisonTextRef = useRef<HTMLSpanElement | null>(null);
+  const textRef = useRef<HTMLSpanElement | null>(null);
+
+  const [showTooltip, setShowTooltip] = useState(false);
+  const [isFinalized, setIsFinalized] = useState(false);
+
+  useLayoutEffect(() => {
+    if (!isFinalized && textRef?.current && comparisonTextRef?.current) {
+      setIsFinalized(true);
+      const textWidth = textRef?.current.getBoundingClientRect().width - PADDING;
+      const comparisonTextWidth = comparisonTextRef?.current.getBoundingClientRect().width;
+      setShowTooltip(comparisonTextWidth > textWidth);
+    }
+  });
+
+  const renderIcon = (): VNode => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    return <Icon type={icon.type} id={displayName} path={icon.path} viewBox={icon.viewBox || '0 0 32 32'} />;
+  };
+
+  const textElement = (
+    <span className={[styles.dropdownItemDescription, showTooltip ? styles.trimText : ''].join(' ')} ref={textRef}>
+      {text}
+    </span>
+  );
+  const comparisonTextElement = (
+    <span ref={comparisonTextRef} className={styles.comparisonText}>
+      {text}
+    </span>
+  );
+  const content = !isFinalized ? (
+    <>
+      {textElement}
+      {comparisonTextElement}
+    </>
+  ) : (
+    textElement
+  );
+
+  const renderContent = (): VNode => {
+    return (
+      <A11yWrapper
+        onClick={(e): void => {
+          onClick(e);
+          onDropdownClick();
+        }}
+        role="menuitem"
+      >
+        <div className={styles.dropdownItem} tabIndex={0} aria-label={text}>
+          <div className={styles.icon}>{renderIcon()}</div>
+          {content}
+        </div>
+      </A11yWrapper>
+    );
+  };
+
+  return <Fragment>{showTooltip ? <Tooltip label={text}>{renderContent()}</Tooltip> : renderContent()}</Fragment>;
+};
+
+export { DropdownBarItem };

--- a/src/services/upper-bar-manager/ui/dropdown-bar-item/dropdown-bar-item.tsx
+++ b/src/services/upper-bar-manager/ui/dropdown-bar-item/dropdown-bar-item.tsx
@@ -79,7 +79,7 @@ const DropdownBarItem = ({ displayName, text, icon, onClick, onDropdownClick, to
       {showTooltip ? (
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        <Tooltip label={text} type={tooltipPosition}>
+        <Tooltip label={text} type={tooltipPosition} className={styles.moreItemTooltip}>
           {renderContent()}
         </Tooltip>
       ) : (

--- a/src/services/upper-bar-manager/ui/dropdown-bar-item/dropdown-bar-item.tsx
+++ b/src/services/upper-bar-manager/ui/dropdown-bar-item/dropdown-bar-item.tsx
@@ -12,11 +12,12 @@ type DropdownBarItemProps = {
   icon: SvgIcon;
   onClick: (e: KeyboardEvent | MouseEvent) => void;
   onDropdownClick: () => void;
+  tooltipPosition: string;
 };
 
 const PADDING = 11;
 
-const DropdownBarItem = ({ displayName, text, icon, onClick, onDropdownClick }: DropdownBarItemProps) => {
+const DropdownBarItem = ({ displayName, text, icon, onClick, onDropdownClick, tooltipPosition }: DropdownBarItemProps) => {
   const comparisonTextRef = useRef<HTMLSpanElement | null>(null);
   const textRef = useRef<HTMLSpanElement | null>(null);
 
@@ -73,8 +74,19 @@ const DropdownBarItem = ({ displayName, text, icon, onClick, onDropdownClick }: 
       </A11yWrapper>
     );
   };
-
-  return <Fragment>{showTooltip ? <Tooltip label={text}>{renderContent()}</Tooltip> : renderContent()}</Fragment>;
+  return (
+    <Fragment>
+      {showTooltip ? (
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        <Tooltip label={text} type={tooltipPosition}>
+          {renderContent()}
+        </Tooltip>
+      ) : (
+        renderContent()
+      )}
+    </Fragment>
+  );
 };
 
 export { DropdownBarItem };

--- a/src/services/upper-bar-manager/ui/dropdown-bar/dropdown-bar.component.scss
+++ b/src/services/upper-bar-manager/ui/dropdown-bar/dropdown-bar.component.scss
@@ -3,38 +3,10 @@
 .more-dropdown {
   position: absolute;
   padding: 8px 4px;
-  width: 166px;  // replace to min-width and grow with text
+  width: 200px;  // replace to min-width and grow with text
   background-color: $tone-7-color;
   border-radius: 4px;
   top: 44px;
   right: 0;
-
-  .dropdown-item {
-    border-radius: 4px;
-    padding: 4px 12px 4px 15px;
-    display: flex;
-    margin: 4px 0;
-    cursor: pointer;
-
-    .icon {
-      width: 24px;
-      height: 24px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    &:hover {
-      background-color: $tone-6-color;
-    }
-
-    .dropdown-item-description {
-      display: flex;
-      flex: 1;
-      font-size: 14px;
-      font-weight: 700;
-      align-items: center;
-      padding-left: 11px;
-    }
-  }
+  overflow: hidden;
 }

--- a/src/services/upper-bar-manager/ui/dropdown-bar/dropdown-bar.component.tsx
+++ b/src/services/upper-bar-manager/ui/dropdown-bar/dropdown-bar.component.tsx
@@ -31,10 +31,11 @@ export class DropdownBar extends Component<DropdownBarProps> {
       style: { maxHeight: `${maxHeightStyle}px` }
     };
 
+    const controlsLength = this.props.controls.length;
     return (
       <div {...dropDownProps}>
         <Scrollable isVertical={true}>
-          {this.props.controls.map(({ id, displayName, ariaLabel, svgIcon, onClick }) => {
+          {this.props.controls.map(({ id, displayName, ariaLabel, svgIcon, onClick }: IconModel, index: number) => {
             const icon = typeof svgIcon === 'function' ? svgIcon() : svgIcon;
             const text = typeof ariaLabel === 'function' ? ariaLabel() : ariaLabel;
             return (
@@ -45,6 +46,7 @@ export class DropdownBar extends Component<DropdownBarProps> {
                 icon={icon}
                 onClick={onClick}
                 onDropdownClick={this.props.onDropdownClick}
+                tooltipPosition={index === controlsLength - 1 ? 'top' : 'bottom'}
               />
             );
           })}

--- a/src/services/upper-bar-manager/ui/dropdown-bar/dropdown-bar.component.tsx
+++ b/src/services/upper-bar-manager/ui/dropdown-bar/dropdown-bar.component.tsx
@@ -13,13 +13,16 @@ type DropdownBarProps = {
   player: KalturaPlayer;
 };
 
-const TOP_BAR_HEIGHT = 60;
 const PADDING_FROM_BOTTOM = 16;
 
 export class DropdownBar extends Component<DropdownBarProps> {
   calculateMaxHeight(): number {
     const playerHeight = this.props.player.getVideoElement().clientHeight;
-    return playerHeight - TOP_BAR_HEIGHT - PADDING_FROM_BOTTOM;
+    // taking the topBarMaxHeight from the window because ui-managers repo is not working with updated ui version
+    // once aligning ui-managers with latest ui we can import ui and get the topBarMaxHeight from there, instead of window
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    return playerHeight - Number(window.KalturaPlayer.ui.style.topBarMaxHeight) - PADDING_FROM_BOTTOM;
   }
 
   render(): ComponentChild {

--- a/src/services/upper-bar-manager/ui/dropdown-bar/dropdown-bar.component.tsx
+++ b/src/services/upper-bar-manager/ui/dropdown-bar/dropdown-bar.component.tsx
@@ -1,39 +1,54 @@
-import { h, Component, ComponentChild, Fragment } from 'preact';
+import { h, Component, ComponentChild } from 'preact';
 import * as styles from './dropdown-bar.component.scss';
 import { IconModel } from '../../models/icon-model';
-import { ui } from '@playkit-js/kaltura-player-js';
-import { A11yWrapper } from '@playkit-js/common/dist/hoc/a11y-wrapper';
-const { Icon } = ui.Components;
+import { KalturaPlayer, ui } from '@playkit-js/kaltura-player-js';
+import { DropdownBarItem } from '../dropdown-bar-item/dropdown-bar-item';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+const { Scrollable } = ui.Components;
 
 type DropdownBarProps = {
   controls: IconModel[];
   onDropdownClick: () => void;
+  player: KalturaPlayer;
 };
 
+const TOP_BAR_HEIGHT = 60;
+const PADDING_FROM_BOTTOM = 16;
+
 export class DropdownBar extends Component<DropdownBarProps> {
+  calculateMaxHeight(): number {
+    const playerHeight = this.props.player.getVideoElement().clientHeight;
+    return playerHeight - TOP_BAR_HEIGHT - PADDING_FROM_BOTTOM;
+  }
+
   render(): ComponentChild {
+    const maxHeightStyle = this.calculateMaxHeight();
+    const dropDownProps = {
+      className: styles.moreDropdown,
+      role: 'menu',
+      ariaExpanded: true,
+      style: { maxHeight: `${maxHeightStyle}px` }
+    };
+
     return (
-      <div className={styles.moreDropdown} role="menu" aria-expanded="true">
-        {this.props.controls.map(({ id, displayName, ariaLabel, svgIcon, onClick }) => {
-          return (
-            <Fragment key={id}>
-              <A11yWrapper
-                onClick={(e): void => {
-                  onClick(e);
-                  this.props.onDropdownClick();
-                }}
-                role="menuitem"
-              >
-                <div className={styles.dropdownItem} tabIndex={0} aria-label={ariaLabel}>
-                  <div className={styles.icon}>
-                    <Icon id={displayName} path={svgIcon.path} viewBox={svgIcon.viewBox || '0 0 32 32'} />
-                  </div>
-                  <span className={styles.dropdownItemDescription}>{displayName}</span>
-                </div>
-              </A11yWrapper>
-            </Fragment>
-          );
-        })}
+      <div {...dropDownProps}>
+        <Scrollable isVertical={true}>
+          {this.props.controls.map(({ id, displayName, ariaLabel, svgIcon, onClick }) => {
+            const icon = typeof svgIcon === 'function' ? svgIcon() : svgIcon;
+            const text = typeof ariaLabel === 'function' ? ariaLabel() : ariaLabel;
+            return (
+              <DropdownBarItem
+                key={id}
+                displayName={displayName}
+                text={text}
+                icon={icon}
+                onClick={onClick}
+                onDropdownClick={this.props.onDropdownClick}
+              />
+            );
+          })}
+        </Scrollable>
       </div>
     );
   }

--- a/src/services/upper-bar-manager/ui/more-icon/more-icon.component.tsx
+++ b/src/services/upper-bar-manager/ui/more-icon/more-icon.component.tsx
@@ -1,6 +1,6 @@
 import { h, Component, ComponentChild, createRef, RefObject } from 'preact';
 import { A11yWrapper } from '@playkit-js/common/dist/hoc/a11y-wrapper';
-import { PlaykitUI, ui } from '@playkit-js/kaltura-player-js';
+import { KalturaPlayer, PlaykitUI, ui } from '@playkit-js/kaltura-player-js';
 import * as styles from './more-icon.component.scss';
 import { IconModel } from '../../models/icon-model';
 import { DropdownBar } from '../dropdown-bar/dropdown-bar.component';
@@ -20,6 +20,7 @@ type MoreIconProps = {
   showDropdown: boolean;
   moreIconTxt?: string;
   eventManager?: EventManager;
+  player: KalturaPlayer;
 };
 
 @withEventManager
@@ -58,7 +59,7 @@ export class MoreIcon extends Component<MoreIconProps> {
         </Tooltip>
         {this.props.showDropdown && (
           <div>
-            <DropdownBar onDropdownClick={this.props.onClick} controls={this.props.icons} />
+            <DropdownBar onDropdownClick={this.props.onClick} controls={this.props.icons} player={this.props.player} />
           </div>
         )}
       </div>

--- a/src/services/upper-bar-manager/upper-bar-manager.tsx
+++ b/src/services/upper-bar-manager/upper-bar-manager.tsx
@@ -19,6 +19,7 @@ export class UpperBarManager {
   private readonly componentsRegistry: Map<number, IconModel>;
   private readonly displayedBarComponentRefs: Record<string, RefObject<DisplayedBar>>;
   private iconsOrder: IconsOrder;
+  private moveControlsManager: MoveControlsManager;
   /**
    * @ignore
    */
@@ -30,7 +31,7 @@ export class UpperBarManager {
     this.iconsOrder = {} as IconsOrder;
     UPPER_BAR_PRESETS.forEach((preset) => (this.displayedBarComponentRefs[preset] = createRef()));
     this.injectDisplayedBarComponentWrapper();
-    new MoveControlsManager(player, logger, this);
+    this.moveControlsManager = new MoveControlsManager(player, logger, this);
   }
 
   public add(icon: IconDto): number | undefined {

--- a/src/services/upper-bar-manager/upper-bar-manager.tsx
+++ b/src/services/upper-bar-manager/upper-bar-manager.tsx
@@ -5,7 +5,7 @@ import { h, RefObject, createRef } from 'preact';
 import { DisplayedBar } from './ui/displayed-bar/displayed-bar.component';
 import { KalturaPluginsDisplayNames } from '../../types/kaltura-plugins-display-names';
 import { MoveControlsManager } from './move-controls-manager';
-const { ReservedPresetAreas, ReservedPresetNames } = ui;
+const { ReservedPresetAreas, ReservedPresetNames, redux } = ui;
 
 const UPPER_BAR_PRESETS = Object.values(ReservedPresetNames).filter(
   (preset) => preset !== ReservedPresetNames.Idle && preset !== ReservedPresetNames.Error
@@ -31,7 +31,7 @@ export class UpperBarManager {
     this.iconsOrder = {} as IconsOrder;
     UPPER_BAR_PRESETS.forEach((preset) => (this.displayedBarComponentRefs[preset] = createRef()));
     this.injectDisplayedBarComponentWrapper();
-    this.moveControlsManager = new MoveControlsManager(player, logger, this);
+    this.moveControlsManager = new MoveControlsManager(player, logger, this, redux);
   }
 
   public add(icon: IconDto): number | undefined {

--- a/src/services/upper-bar-manager/upper-bar-manager.tsx
+++ b/src/services/upper-bar-manager/upper-bar-manager.tsx
@@ -4,6 +4,7 @@ import { IconModel } from './models/icon-model';
 import { h, RefObject, createRef } from 'preact';
 import { DisplayedBar } from './ui/displayed-bar/displayed-bar.component';
 import { KalturaPluginsDisplayNames } from '../../types/kaltura-plugins-display-names';
+import { MoveControlsManager } from './move-controls-manager';
 const { ReservedPresetAreas, ReservedPresetNames } = ui;
 
 const UPPER_BAR_PRESETS = Object.values(ReservedPresetNames).filter(
@@ -29,6 +30,7 @@ export class UpperBarManager {
     this.iconsOrder = {} as IconsOrder;
     UPPER_BAR_PRESETS.forEach((preset) => (this.displayedBarComponentRefs[preset] = createRef()));
     this.injectDisplayedBarComponentWrapper();
+    new MoveControlsManager(player, logger, this);
   }
 
   public add(icon: IconDto): number | undefined {
@@ -85,6 +87,7 @@ export class UpperBarManager {
             <DisplayedBar
               ref={this.displayedBarComponentRefs[preset]}
               getControls={(): IconModel[] => this.getControls(iconsOrder).filter((icon) => icon.presets.includes(preset))}
+              player={this.player}
             />
           );
         }

--- a/tests/e2e/move-controls-manager.spec.js
+++ b/tests/e2e/move-controls-manager.spec.js
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import { createSandbox } from 'sinon';
+import '../../src/index';
+import '../mock/plugins/index';
+import { MoveControlsManager } from '../../src/services/upper-bar-manager/move-controls-manager';
+
+describe('Move Controls Manager', () => {
+  const bottomBarRegistryManager = {
+    getComponentItem: () => {
+      return {
+        ariaLabel: 'aria-label'
+      };
+    }
+  };
+
+  const player = {
+    getService: () => {
+      return bottomBarRegistryManager;
+    }
+  };
+
+  const logger = {
+    debug: () => {}
+  };
+
+  const upperBarManager = {
+    add: () => 3,
+    remove: () => {}
+  };
+
+  const redux = {
+    useStore: () => {},
+    subscribe: () => {}
+  };
+
+  const sandbox = createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('Should add PictureInPicture to the upper bar', async () => {
+    // Given
+    sandbox.stub(redux, 'useStore').returns({
+      subscribe: () => {},
+      getState: () => {
+        return { bottomBar: { controlsToMove: [] } };
+      }
+    });
+    sandbox.stub(redux, 'subscribe').returns({});
+    const manager = new MoveControlsManager(player, logger, upperBarManager, redux);
+    sandbox.stub(manager, 'state').get(() => {
+      return { bottomBar: { controlsToMove: ['PictureInPicture'] } };
+    });
+    const spy = sandbox.spy(manager.upperBarManager, 'add');
+
+    // Do
+    manager.handleStoreChange();
+
+    // Expect
+    spy.calledOnce;
+    expect(manager.iconIds.size).to.equal(1);
+    expect(manager.iconIds.get('PictureInPicture')).to.equal(3);
+  });
+
+  it('Should remove PictureInPicture from the upper bar', async () => {
+    // Given
+    sandbox.stub(redux, 'useStore').returns({
+      subscribe: () => {},
+      getState: () => {
+        return { bottomBar: { controlsToMove: ['PictureInPicture'] } };
+      }
+    });
+    sandbox.stub(redux, 'subscribe').returns({});
+    const manager = new MoveControlsManager(player, logger, upperBarManager, redux);
+    sandbox.stub(manager, 'state').get(() => {
+      return { bottomBar: { controlsToMove: [] } };
+    });
+
+    // Do
+    manager.handleStoreChange();
+
+    // Expect
+    expect(manager.iconIds.size).to.equal(0);
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,7 +51,8 @@ module.exports = (env, { mode }) => {
     },
     externals: {
       '@playkit-js/kaltura-player-js': 'root KalturaPlayer',
-      preact: 'root KalturaPlayer.ui.preact'
+      preact: 'root KalturaPlayer.ui.preact',
+      'preact/hooks': 'root KalturaPlayer.ui.preactHooks',
     },
     devServer: {
       static: {


### PR DESCRIPTION
### Description of the Changes

following a new requirement to move core controls to the upper bar, in case there is not enough space for them:
- add a new manager that adds controls to the upper bar, according to redux state
- address design requirements for the `More` drop-down menu component:
  - trim text if theres is not enough space
  - add tooltip around the text if it is trimmed

related PR- https://github.com/kaltura/playkit-js-ui/pull/898

Solves FEC-13945

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
