### PR TITLE
fix(FEC-14076): Player v7 | Download | Download notification popup is being display behind download overlay.

### DIFF
--- a/src/services/toast-manager/ui/toasts-container/toasts-container.scss
+++ b/src/services/toast-manager/ui/toasts-container/toasts-container.scss
@@ -1,10 +1,11 @@
 .toastsContainer {
     position: absolute;
+    z-index: 9999;
+
     min-width: 120px;
     max-width: 310px;
     display: flex;
     flex-direction: column;
-    z-index: 2;
     &.top-right {
         right: 0;
         top: 0;


### PR DESCRIPTION
### Description of the Changes

Change the toasts container z index from 2 to 9999 to make it appear on top of everything else

Related PR:


Resolves: FEC-14076

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
