### PR TITLE
fix(ADA-1451): Close Video Info modal dialog focus management

### DIFF
--- a/src/services/upper-bar-manager/ui/displayed-bar/displayed-bar.component.tsx
+++ b/src/services/upper-bar-manager/ui/displayed-bar/displayed-bar.component.tsx
@@ -1,4 +1,4 @@
-import { h, Component, ComponentChild, RefObject } from 'preact';
+import {h, Component, ComponentChild, RefObject, createRef} from 'preact';
 import { IconModel } from '../../models/icon-model';
 import { IconWrapper } from '../icon-wrapper/icon-wrapper.component';
 import * as styles from './displayed-bar.component.scss';
@@ -32,6 +32,7 @@ type PropsFromRedux = {
 // @ts-ignore
 @connect(mapStateToProps, null, null, { forwardRef: true })
 export class DisplayedBar extends Component<DisplayedBarProps & PropsFromRedux, DisplayedBarState> {
+  public moreIconRef = createRef<MoreIcon>();
   constructor() {
     super();
     this.state = { showDropdown: false };
@@ -109,6 +110,9 @@ export class DisplayedBar extends Component<DisplayedBarProps & PropsFromRedux, 
             onClick={this.handleOnClick}
             icons={dropdownControls}
             player={this.props.player}
+            ref={(node) => {
+              this.moreIconRef.current = node;
+            }}
           />
         )}
       </div>

--- a/src/services/upper-bar-manager/ui/displayed-bar/displayed-bar.component.tsx
+++ b/src/services/upper-bar-manager/ui/displayed-bar/displayed-bar.component.tsx
@@ -1,4 +1,4 @@
-import {h, Component, ComponentChild, RefObject, createRef} from 'preact';
+import { h, Component, ComponentChild, RefObject, createRef } from 'preact';
 import { IconModel } from '../../models/icon-model';
 import { IconWrapper } from '../icon-wrapper/icon-wrapper.component';
 import * as styles from './displayed-bar.component.scss';

--- a/src/services/upper-bar-manager/upper-bar-manager.tsx
+++ b/src/services/upper-bar-manager/upper-bar-manager.tsx
@@ -76,6 +76,12 @@ export class UpperBarManager {
     return icons.sort((a, b) => iconsOrder[a.displayName] - iconsOrder[b.displayName]);
   }
 
+  public getMorePluginButton() {
+    const rightControls = this.displayedBarComponentRefs.Playback.current?.base as HTMLElement;
+    const buttons = rightControls.querySelectorAll('[tabindex="0"]');
+    return Array.from(buttons).find((button) => button.classList.contains('playkit-more-icon_fR')) as HTMLButtonElement;
+  }
+
   public focusPluginButton(pluginId: number) {
     let pluginButton;
     const controls = this.getControls(this.iconsOrder);
@@ -83,9 +89,7 @@ export class UpperBarManager {
     if (pluginElement) {
       pluginButton = pluginElement.querySelector('[tabindex="0"]') as HTMLElement;
     } else {
-      const rightControls = this.displayedBarComponentRefs.Playback.current?.base as HTMLElement;
-      const buttons = rightControls.querySelectorAll('[tabindex="0"]');
-      pluginButton = buttons[buttons.length - 1] as HTMLElement;
+      pluginButton = this.getMorePluginButton();
     }
     pluginButton?.focus();
   }

--- a/src/services/upper-bar-manager/upper-bar-manager.tsx
+++ b/src/services/upper-bar-manager/upper-bar-manager.tsx
@@ -77,9 +77,8 @@ export class UpperBarManager {
   }
 
   public getMorePluginButton() {
-    const rightControls = this.displayedBarComponentRefs.Playback.current?.base as HTMLElement;
-    const buttons = rightControls.querySelectorAll('[tabindex="0"]');
-    return Array.from(buttons).find((button) => button.classList.contains('playkit-more-icon_fR')) as HTMLButtonElement;
+    const moreElement = this.displayedBarComponentRefs.Playback.current?.moreIconRef?.current?.base as HTMLElement;
+    return moreElement?.querySelector('[tabindex="0"]') as HTMLButtonElement;
   }
 
   public focusPluginButton(pluginId: number) {


### PR DESCRIPTION
### Description of the Changes

create function to select the more plugin button from right controls elements.

part of:
https://github.com/kaltura/playkit-js-ui/pull/958
https://github.com/kaltura/playkit-js-info/pull/106

solves [ADA-1451](https://kaltura.atlassian.net/browse/ADA-1451) 

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[ADA-1451]: https://kaltura.atlassian.net/browse/ADA-1451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ